### PR TITLE
Encode URL for SPARQL adapter

### DIFF
--- a/database/databaseUtilities/backends/sparql/adapter.js
+++ b/database/databaseUtilities/backends/sparql/adapter.js
@@ -77,17 +77,19 @@ class SparqlAdapter {
         }
 
         logger.debug(`loadCoreQueryDataFromDB SPARQL query: ${query}`);
-        const url = this.configFile.url + "?query=" + query;
+        const url = this.configFile.url + "?query=" + encodeURIComponent(equery);
         let response = undefined;
         try {
             response = await fetch(url, { method: "GET", headers: headers }).then(res => res.text());
-
         } catch (err) {
             throw Error("Could not fetch data from SPARQL");
         }
         try {
             if (!(response.includes("error"))) {
                 await database.insertRDF(response);
+            } else {
+                logger.error("Failed to query endpoint.")
+                logger.debug("Error response: ${response}")
             }
         } catch (err) {
             throw Error("Could not insert RDF into graphy");

--- a/database/databaseUtilities/backends/sparql/adapter.js
+++ b/database/databaseUtilities/backends/sparql/adapter.js
@@ -77,7 +77,7 @@ class SparqlAdapter {
         }
 
         logger.debug(`loadCoreQueryDataFromDB SPARQL query: ${query}`);
-        const url = this.configFile.url + "?query=" + encodeURIComponent(equery);
+        const url = this.configFile.url + "?query=" + encodeURIComponent(query);
         let response = undefined;
         try {
             response = await fetch(url, { method: "GET", headers: headers }).then(res => res.text());


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #79 

# How Has This Been Tested?
Yes
```
const staple = require("staple-api");

let ontology = `
@prefix schema: <http://schema.org/> .
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@prefix dcat: <http://www.w3.org/ns/dcat#> .
@prefix dcterms: <http://purl.org/dc/terms/> .
@prefix example: <http://example.com#> .

dcat:Dataset a rdfs:Class ;
  rdfs:comment "Dataset" .

dcterms:title a rdf:Property, owl:FunctionalProperty ;
  rdfs:comment "title" ;
  schema:domainIncludes dcat:Dataset ;
  schema:rangeIncludes xsd:string .

`;


let config = {
  dataSources: {
    default: "source",
    source: {
      type: "sparql",
      url: "https://www.europeandataportal.eu/sparql",
      updateUrl: "",
      graphName: "",
      description: "SPARQL endpoint"
    }
  }
};

async function StapleDemo() {
  let stapleApi = await staple(ontology, config);
  await stapleApi.graphql('{ Dataset (page:1) { _id } }')
    .then((response) => console.log(JSON.stringify(response)));
}

StapleDemo()

```

# Checklist:

